### PR TITLE
Fix include/exclude naming in ant-javacard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ Note2 : you can add as many `local` or `remote` dependency as you want
       * findSources [boolean] - default:true, if true the sources are determined automatically. The first existing source dir in source sets is taken
       * defaultSources [boolean] - default:true, if true the first source dir from the source set is used. Otherwise the most recet (last)
       * classes [String] - path to pre-compiled class files to be assembled into a CAP file. If both classes and sources are specified, compiled class files will be put to classes folder, which is created if missing
-      * include [String] - comma or space separated list of patterns of files that must be included.
-      * exclude [String] - comma or space separated list of patterns of files that must be excluded.
+      * includes [String] - comma or space separated list of patterns of files that must be included.
+      * excludes [String] - comma or space separated list of patterns of files that must be excluded.
       * packageName [String] - name of the package of the CAP file. Optional - set to the parent package of the applet class if left unspecified.
       * version [String] - version of the package. Optional - defaults to 0.0 if left unspecified.
       * aid [String] - AID (hex) of the package. Recommended - or set to the 5 first bytes of the applet AID if left unspecified.

--- a/gradle-javacard/src/main/groovy/com/klinec/gradle/javacard/JavaCardBuildTask.groovy
+++ b/gradle-javacard/src/main/groovy/com/klinec/gradle/javacard/JavaCardBuildTask.groovy
@@ -145,11 +145,11 @@ class JavaCardBuildTask extends DefaultTask {
         if (capItem.classes?.trim()) {
             map["classes"] = capItem.classes
         }
-        if (capItem.include?.trim()) {
-            map["include"] = capItem.include
+        if (capItem.includes?.trim()) {
+            map["includes"] = capItem.includes
         }
-        if (capItem.exclude?.trim()) {
-            map["exclude"] = capItem.exclude
+        if (capItem.excludes?.trim()) {
+            map["excludes"] = capItem.excludes
         }
         if (capItem.packageName?.trim()) {
             map["package"] = capItem.packageName

--- a/gradle-javacard/src/main/groovy/com/klinec/gradle/javacard/extension/Cap.groovy
+++ b/gradle-javacard/src/main/groovy/com/klinec/gradle/javacard/extension/Cap.groovy
@@ -77,12 +77,12 @@ abstract class Cap {
     /**
      * comma or space separated list of patterns of files that must be included.
      */
-    String include
+    String includes
 
     /**
      * comma or space separated list of patterns of files that must be excluded.
      */
-    String exclude
+    String excludes
 
     /**
      * name of the package of the CAP file. Optional - set to the parent package of the applet class if left unspecified.
@@ -207,12 +207,12 @@ abstract class Cap {
         this.aid = aid
     }
 
-    void include(String include) {
-        this.include = include
+    void includes(String includes) {
+        this.includes = includes
     }
 
-    void exclude(String exclude) {
-        this.exclude = exclude
+    void excludes(String excludes) {
+        this.excludes = excludes
     }
 
     void output(String output) {


### PR DESCRIPTION
ant-javacard does not have `include`/`exclude` but `includes`/`excludes`, this fixes that.